### PR TITLE
add yaml_parser capability

### DIFF
--- a/bot/utilities/__init__.py
+++ b/bot/utilities/__init__.py
@@ -1,0 +1,28 @@
+def get_config_val(*strings: str) -> dict:
+
+    import yaml
+    from string import punctuation
+
+    return_dict = {}
+
+    for string in strings:
+
+        sep_string = "".join([" " if char in punctuation else char for char in string]).split()
+
+        with open("config.yaml") as config:
+
+            data = yaml.load(config, Loader=yaml.UnsafeLoader)
+
+            for key in sep_string:
+
+                if key in data:
+
+                    data = data[key]
+
+                    if key == sep_string[-1]:
+                        return_dict[key] = data
+
+                else:
+                    raise yaml.YAMLError(f'Key "{key}" cannot be found')
+
+    return return_dict

--- a/bot/utilities/__init__.py
+++ b/bot/utilities/__init__.py
@@ -1,4 +1,4 @@
-def get_config_val(*strings: str) -> dict:
+def get_config_val(yaml_file: str, *strings: str) -> dict:
 
     import yaml
     from string import punctuation
@@ -9,7 +9,7 @@ def get_config_val(*strings: str) -> dict:
 
         sep_string = "".join([" " if char in punctuation else char for char in string]).split()
 
-        with open("config.yaml") as config:
+        with open(yaml_file) as config:
 
             data = yaml.load(config, Loader=yaml.UnsafeLoader)
 

--- a/bot/utilities/__init__.py
+++ b/bot/utilities/__init__.py
@@ -6,7 +6,6 @@ def get_config_val(yaml_file: str, *strings: str) -> dict:
     return_dict = {}
 
     for string in strings:
-
         sep_string = "".join([" " if char in punctuation else char for char in string]).split()
 
         with open(yaml_file) as config:
@@ -14,9 +13,8 @@ def get_config_val(yaml_file: str, *strings: str) -> dict:
             data = yaml.load(config, Loader=yaml.UnsafeLoader)
 
             for key in sep_string:
-
+                
                 if key in data:
-
                     data = data[key]
 
                     if key == sep_string[-1]:


### PR DESCRIPTION
Closes #14.

I finished a function that'll parse any yaml file given. It'll open the yaml file, and iterate over an arbitrary amount of arguments after. These arbitrary arguments are the location of the value in the nested dictionary, separated by any ascii punctuation mark.

e.x.
`d = {"bonk": 1, "lonk": {"tonk": 2}}`, to get `bonk`'s value, the string repr would be `bonk`. To get `tonk`'s value, the string repr would be `lonk.tonk`.

Any issues, let me know.