### PR TITLE
Added `--help` command

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -28,11 +28,11 @@ class Bot(commands.Bot):
             dot_path = str(extension).replace(os.sep, ".")[:-3]
 
             self.load_extension(dot_path)
-            logger.info(f"Successfully loaded extension:  {dot_path}")
+            logger.info(f"Successfully loaded extension:  {dot_path}.")
 
     def run(self) -> None:
         """Run the bot with the token in constants.py/.env ."""
-        logger.info("Starting bot")
+        logger.info("Starting bot.")
         if constants.TOKEN is None:
             raise EnvironmentError(
                 "token value is None. "
@@ -42,7 +42,7 @@ class Bot(commands.Bot):
 
     async def on_ready(self) -> None:
         """Ran when the bot has connected to discord and is ready."""
-        logger.info("Bot online")
+        logger.info("Bot online.")
         await self.startup_greeting()
         self.load_extensions()
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -17,7 +17,9 @@ class Bot(commands.Bot):
         intents.presences = True
 
         self.http_session = ClientSession()
-        super().__init__(command_prefix=constants.PREFIX, help_command=None, intents=intents)
+        super().__init__(
+            command_prefix=constants.PREFIX, help_command=None, intents=intents
+        )
 
     def load_extensions(self) -> None:
         """Load all the extensions in the exts/ folder."""
@@ -29,6 +31,8 @@ class Bot(commands.Bot):
 
             self.load_extension(dot_path)
             logger.info(f"Successfully loaded extension:  {dot_path}.")
+
+    docs = {}
 
     def run(self) -> None:
         """Run the bot with the token in constants.py/.env ."""

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -32,7 +32,6 @@ class Bot(commands.Bot):
             self.load_extension(dot_path)
             logger.info(f"Successfully loaded extension:  {dot_path}.")
 
-
     def run(self) -> None:
         """Run the bot with the token in constants.py/.env ."""
         logger.info("Starting bot.")

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -17,7 +17,7 @@ class Bot(commands.Bot):
         intents.presences = True
 
         self.http_session = ClientSession()
-        super().__init__(command_prefix=constants.PREFIX, intents=intents)
+        super().__init__(command_prefix=constants.PREFIX, help_command=None, intents=intents)
 
     def load_extensions(self) -> None:
         """Load all the extensions in the exts/ folder."""

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -32,7 +32,6 @@ class Bot(commands.Bot):
             self.load_extension(dot_path)
             logger.info(f"Successfully loaded extension:  {dot_path}.")
 
-    docs = {}
 
     def run(self) -> None:
         """Run the bot with the token in constants.py/.env ."""

--- a/bot/exts/fun/catify.py
+++ b/bot/exts/fun/catify.py
@@ -94,3 +94,5 @@ class Catify(commands.Cog):
 def setup(bot: commands.Bot) -> None:
     """Loads the catify cog."""
     bot.add_cog(Catify(bot))
+    docs = {"catify": f"{Catify.catify.help}"}
+    bot.docs.update(docs)

--- a/bot/exts/fun/catify.py
+++ b/bot/exts/fun/catify.py
@@ -94,5 +94,3 @@ class Catify(commands.Cog):
 def setup(bot: commands.Bot) -> None:
     """Loads the catify cog."""
     bot.add_cog(Catify(bot))
-    docs = {"catify": f"{Catify.catify.help}"}
-    bot.docs.update(docs)

--- a/bot/exts/fun/fun.py
+++ b/bot/exts/fun/fun.py
@@ -73,5 +73,3 @@ class Fun(commands.Cog):
 
 def setup(bot: commands.Bot):
     bot.add_cog(Fun(bot))
-    docs = {"eval": Fun.eval.help, "duck": Fun.duck.help}
-    bot.docs.update(docs)

--- a/bot/exts/fun/fun.py
+++ b/bot/exts/fun/fun.py
@@ -21,6 +21,7 @@ class Fun(commands.Cog):
     async def eval(
         self, ctx: commands.Context, language: str = "python3", *, code: str = None
     ):
+        """Evaluates code using tio.run."""
         site = Tio()
         if code.strip("`"):
             # Code in message
@@ -49,6 +50,7 @@ class Fun(commands.Cog):
 
     @commands.command(aliases=["quack"])
     async def duck(self, ctx, typeofduck: str = "duck") -> None:
+        """Generates a random duck or manduck using Quackstack."""
         now = datetime.datetime.now(cst)
         if typeofduck not in ["duck", "manduck"]:
             await ctx.send("That is not a valid duck type!")
@@ -71,3 +73,5 @@ class Fun(commands.Cog):
 
 def setup(bot: commands.Bot):
     bot.add_cog(Fun(bot))
+    docs = {"eval": Fun.eval.help, "duck": Fun.duck.help}
+    bot.docs.update(docs)

--- a/bot/exts/fun/makeembed.py
+++ b/bot/exts/fun/makeembed.py
@@ -158,5 +158,3 @@ class makeembed(commands.Cog):
 
 def setup(bot):
     bot.add_cog(makeembed(bot))
-    docs = {"makeembed": makeembed.makeembed.help}
-    bot.docs.update(docs)

--- a/bot/exts/fun/makeembed.py
+++ b/bot/exts/fun/makeembed.py
@@ -11,6 +11,7 @@ class makeembed(commands.Cog):
 
     @commands.command()
     async def makeembed(self, ctx):
+        """Makes an embed based on parameters set by the user."""
         data = get_yaml_val("config.yml", "colors")["colors"]
 
         questions = [
@@ -157,3 +158,5 @@ class makeembed(commands.Cog):
 
 def setup(bot):
     bot.add_cog(makeembed(bot))
+    docs = {"makeembed": makeembed.makeembed.help}
+    bot.docs.update(docs)

--- a/bot/exts/fun/zencat.py
+++ b/bot/exts/fun/zencat.py
@@ -41,6 +41,7 @@ class Zen(commands.Cog):
 
     @commands.command(aliases=["zenofpycat", "zen"])
     async def zencat(self, ctx: commands.Context, index: Optional[int]) -> None:
+        """Sends a modified version of the python zen."""
         rand_color = COLORS[random.choice(list(COLORS.keys()))]
 
         if index is None:
@@ -83,3 +84,5 @@ class Zen(commands.Cog):
 def setup(bot: commands.Bot) -> None:
     """Loads the Zen cog."""
     bot.add_cog(Zen(bot))
+    docs = {"zencat": Zen.zencat.help}
+    bot.docs.update(docs)

--- a/bot/exts/fun/zencat.py
+++ b/bot/exts/fun/zencat.py
@@ -84,5 +84,3 @@ class Zen(commands.Cog):
 def setup(bot: commands.Bot) -> None:
     """Loads the Zen cog."""
     bot.add_cog(Zen(bot))
-    docs = {"zencat": Zen.zencat.help}
-    bot.docs.update(docs)

--- a/bot/exts/moderation/moderation.py
+++ b/bot/exts/moderation/moderation.py
@@ -172,9 +172,3 @@ class Moderation(commands.Cog):
 def setup(bot: commands.Bot):
     """Loads cog."""
     bot.add_cog(Moderation(bot))
-    docs = {
-        "pban": Moderation.pban.help,
-        "mute": Moderation.mute.help,
-        "purge": Moderation.purge.help,
-    }
-    bot.docs.update(docs)

--- a/bot/exts/moderation/moderation.py
+++ b/bot/exts/moderation/moderation.py
@@ -36,6 +36,7 @@ class Moderation(commands.Cog):
         *,
         reason: str = "Badly behaved",
     ):
+        """Permanently bans a user."""
         if user == self.bot.user:
             await ctx.send("You can't ban me!")
             return
@@ -62,6 +63,7 @@ class Moderation(commands.Cog):
         *,
         reason: str = "Because of naughtiness",
     ):
+        """Mutes a user for a set amount of time."""
         if user == self.bot.user:
             await ctx.send("You can't mute me!")
             return
@@ -123,6 +125,7 @@ class Moderation(commands.Cog):
     async def purge(
         self, ctx: commands.Context, limit: int, *, reason: str = None
     ) -> None:
+        """Deletes a set amount of messages."""
 
         if not 0 < int(limit) < 200:
             await ctx.send("Please purge between 0 and 200 messages.")
@@ -169,3 +172,9 @@ class Moderation(commands.Cog):
 def setup(bot: commands.Bot):
     """Loads cog."""
     bot.add_cog(Moderation(bot))
+    docs = {
+        "pban": Moderation.pban.help,
+        "mute": Moderation.mute.help,
+        "purge": Moderation.purge.help,
+    }
+    bot.docs.update(docs)

--- a/bot/exts/utilities/help.py
+++ b/bot/exts/utilities/help.py
@@ -27,10 +27,7 @@ class Help(commands.Cog):
             for element in self.bot.commands:
                 commandraw = self.bot.get_command(element.qualified_name)
                 help = commandraw.help
-                embed.add_field(
-                    name=element.qualified_name,
-                    value=f"*{help}*"
-                )
+                embed.add_field(name=element.qualified_name, value=f"*{help}*")
             await ctx.send(embed=embed)
         elif command not in self.bot.commands:
             commandraw = self.bot.get_command(command.lower())

--- a/bot/exts/utilities/help.py
+++ b/bot/exts/utilities/help.py
@@ -24,8 +24,13 @@ class Help(commands.Cog):
                 description=f"A detailed list of all commands. For help on a specific command, do `{bot.constants.PREFIX}help [command]`.",
                 color=colors["light_blue"],
             )
-            for key, value in self.bot.docs.items():
-                embed.add_field(name=key, value=value)
+            for element in self.bot.commands:
+                commandraw = self.bot.get_command(element.qualified_name)
+                help = commandraw.help
+                embed.add_field(
+                    name=element.qualified_name,
+                    value=f"*{help}*"
+                )
             await ctx.send(embed=embed)
         elif command not in self.bot.commands:
             commandraw = self.bot.get_command(command.lower())
@@ -33,7 +38,7 @@ class Help(commands.Cog):
                 await ctx.send(f"`{command}` is an invalid command!")
                 return
             name = commandraw.qualified_name
-            help = self.bot.docs.get(name)
+            help = commandraw.help
             alias_list = commandraw.aliases
             usage = commandraw.signature
             embed = discord.Embed(
@@ -49,10 +54,10 @@ class Help(commands.Cog):
             await ctx.send(embed=embed)
         else:
             command = command.lower()
-            command_data = self.bot.docs.get(command)
-            command_args = self.bot.get_command(command)
-            alias_list = command_args.aliases
-            command_args = command_args.signature
+            commandraw = self.bot.get_command(command)
+            command_data = commandraw.help
+            alias_list = commandraw.aliases
+            command_args = commandraw.signature
             embed = discord.Embed(
                 title=f"Help: {command}",
                 description=f"*{command_data}*",
@@ -71,5 +76,3 @@ class Help(commands.Cog):
 def setup(bot: commands.Bot):
     """Loads cog."""
     bot.add_cog(Help(bot))
-    docs = {"help": Help.help.help}
-    bot.docs.update(docs)

--- a/bot/exts/utilities/help.py
+++ b/bot/exts/utilities/help.py
@@ -21,7 +21,8 @@ class Help(commands.Cog):
         if not command:
             embed = discord.Embed(
                 title="Help: All",
-                description=f"A detailed list of all commands. For help on a specific command, do `{bot.constants.PREFIX}help [command]`.",
+                description=f"A detailed list of all commands. For help on a specific command, "
+                f"do `{bot.constants.PREFIX}help [command]`.",
                 color=colors["light_blue"],
             )
             for element in self.bot.commands:

--- a/bot/exts/utilities/help.py
+++ b/bot/exts/utilities/help.py
@@ -1,16 +1,75 @@
+from typing import Optional
+
 from discord.ext import commands
 import discord
 
+from bot.utilities import get_yaml_val
+import bot.constants
+
+colors = get_yaml_val("config.yml", "colors")["colors"]
+
+
 class Help(commands.Cog):
     """Cog for the help command."""
+
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
     @commands.command()
-    async def help(self, ctx: commands.context):
-        for command in self.ctx.commands:
-            await ctx.send(command)
+    async def help(self, ctx: commands.Context, command: Optional[str] = None):
+        """This help command."""
+        if not command:
+            embed = discord.Embed(
+                title="Help: All",
+                description=f"A detailed list of all commands. For help on a specific command, do `{bot.constants.PREFIX}help [command]`.",
+                color=colors["light_blue"],
+            )
+            for key, value in self.bot.docs.items():
+                embed.add_field(name=key, value=value)
+            await ctx.send(embed=embed)
+        elif command not in self.bot.commands:
+            commandraw = self.bot.get_command(command.lower())
+            if commandraw is None:
+                await ctx.send(f"`{command}` is an invalid command!")
+                return
+            name = commandraw.qualified_name
+            help = self.bot.docs.get(name)
+            alias_list = commandraw.aliases
+            usage = commandraw.signature
+            embed = discord.Embed(
+                title=f"Help: {name}",
+                description=f"*{help}*",
+                color=colors["light_blue"],
+            )
+            aliases = ", ".join(alias_list)
+            embed.add_field(
+                name="Usage", value=f"`{bot.constants.PREFIX}{name}{usage}`"
+            )
+            embed.add_field(name="Can also use", value=f"*{aliases}*")
+            await ctx.send(embed=embed)
+        else:
+            command = command.lower()
+            command_data = self.bot.docs.get(command)
+            command_args = self.bot.get_command(command)
+            alias_list = command_args.aliases
+            command_args = command_args.signature
+            embed = discord.Embed(
+                title=f"Help: {command}",
+                description=f"*{command_data}*",
+                color=colors["light_blue"],
+            )
+            aliases = ", ".join(alias_list)
+
+            embed.add_field(
+                name="Usage", value=f"`{bot.constants.PREFIX}{command}{command_args}`"
+            )
+            if aliases != "":
+                embed.add_field(name="Can also use", value=f"*{aliases}*")
+            await ctx.send(embed=embed)
+
 
 def setup(bot: commands.Bot):
     """Loads cog."""
     bot.add_cog(Help(bot))
+    docs = {"help": Help.help.help}
+    bot.docs.update(docs)

--- a/bot/exts/utilities/help.py
+++ b/bot/exts/utilities/help.py
@@ -25,11 +25,14 @@ class Help(commands.Cog):
                 f"do `{bot.constants.PREFIX}help [command]`.",
                 color=colors["light_blue"],
             )
+
             for element in self.bot.commands:
                 commandraw = self.bot.get_command(element.qualified_name)
                 help = commandraw.help
                 embed.add_field(name=element.qualified_name, value=f"*{help}*")
+
             await ctx.send(embed=embed)
+
         elif command not in self.bot.commands:
             commandraw = self.bot.get_command(command.lower())
             if commandraw is None:
@@ -39,15 +42,18 @@ class Help(commands.Cog):
             help = commandraw.help
             alias_list = commandraw.aliases
             usage = commandraw.signature
+
             embed = discord.Embed(
                 title=f"Help: {name}",
                 description=f"*{help}*",
                 color=colors["light_blue"],
             )
+
             aliases = ", ".join(alias_list)
             embed.add_field(
                 name="Usage", value=f"`{bot.constants.PREFIX}{name}{usage}`"
             )
+
             embed.add_field(name="Can also use", value=f"*{aliases}*")
             await ctx.send(embed=embed)
         else:
@@ -56,18 +62,22 @@ class Help(commands.Cog):
             command_data = commandraw.help
             alias_list = commandraw.aliases
             command_args = commandraw.signature
+
             embed = discord.Embed(
                 title=f"Help: {command}",
                 description=f"*{command_data}*",
                 color=colors["light_blue"],
             )
+
             aliases = ", ".join(alias_list)
 
             embed.add_field(
                 name="Usage", value=f"`{bot.constants.PREFIX}{command}{command_args}`"
             )
+
             if aliases != "":
                 embed.add_field(name="Can also use", value=f"*{aliases}*")
+
             await ctx.send(embed=embed)
 
 


### PR DESCRIPTION
Closes #46 

`--help` on its own returns a list of commands, but `--help [command or alias]` returns help on that command.