### PR TITLE
made bot send dm to person getting infracted.

### DIFF
--- a/bot/exts/moderation/moderation.py
+++ b/bot/exts/moderation/moderation.py
@@ -55,7 +55,11 @@ class Moderation(commands.Cog):
         #dm embed made here
         dm_message = discord.Embed(
             title = "**Infraction**: Ban",
-            description = f"You just got banned from the `{ctx.guild}` server.\n`reason:` {reason}\n`date and time:` {current_time} {current_date}",
+            description = (
+                f"You just got banned from the `{ctx.guild}` server.\n"
+                f"`reason:` {reason}\n"
+                f"`date and time:` {current_time} {current_date}"
+            )
             color = colors["light_blue"]
         )
 
@@ -132,7 +136,12 @@ class Moderation(commands.Cog):
         #dm embed made here
         dm_message = discord.Embed(
             title = "**Infraction**: Mute",
-            description = f"You just got muted from the `{ctx.guild}` server.\n`duration:` until {unmute_time}\n`reason:` {reason}\n`date and time:` {current_time} {current_date}",
+            description = (
+                f"You just got muted from the `{ctx.guild}` server.\n"
+                f"`duration:` until {unmute_time}\n"
+                f"`reason:` {reason}\n"
+                f"`date and time:` {current_time} {current_date}"
+            )
             color = colors["light_blue"]
         )
 

--- a/bot/exts/moderation/moderation.py
+++ b/bot/exts/moderation/moderation.py
@@ -45,22 +45,22 @@ class Moderation(commands.Cog):
             await ctx.send("You can't ban yourself!")
             return
 
-        #gets current date and time; converts it with colons and slashes between then to make sense
+        # gets current date and time; converts it with colons and slashes between then to make sense
         current_time = datetime.now()
         current_time = current_time.strftime("%H:%M:%S")
 
         current_date = datetime.date()
         current_date = current_date.strftime("%d/%m/%y")
 
-        #dm embed made here
+        # dm embed made here
         dm_message = discord.Embed(
-            title = "**Infraction**: Ban",
-            description = (
+            title="**Infraction**: Ban",
+            description=(
                 f"You just got banned from the `{ctx.guild}` server.\n"
                 f"`reason:` {reason}\n"
                 f"`date and time:` {current_time} {current_date}"
-            )
-            color = colors["light_blue"]
+            ),
+            color=colors["light_blue"],
         )
 
         await user.dm_channel.send(embed=dm_message)
@@ -126,23 +126,23 @@ class Moderation(commands.Cog):
 
         await user.add_roles(muted_role)
 
-        #gets current date and time; converts it with colons and slashes between then to make sense
+        # gets current date and time; converts it with colons and slashes between then to make sense
         current_time = datetime.now()
         current_time = current_time.strftime("%H:%M:%S")
 
         current_date = datetime.date()
         current_date = current_date.strftime("%d/%m/%y")
 
-        #dm embed made here
+        # dm embed made here
         dm_message = discord.Embed(
-            title = "**Infraction**: Mute",
-            description = (
+            title="**Infraction**: Mute",
+            description=(
                 f"You just got muted from the `{ctx.guild}` server.\n"
                 f"`duration:` until {unmute_time}\n"
                 f"`reason:` {reason}\n"
                 f"`date and time:` {current_time} {current_date}"
-            )
-            color = colors["light_blue"]
+            ),
+            color=colors["light_blue"],
         )
 
         await user.dm_channel.send(embed=dm_message)

--- a/bot/exts/moderation/moderation.py
+++ b/bot/exts/moderation/moderation.py
@@ -226,6 +226,14 @@ class Moderation(commands.Cog):
 
         await user.remove_roles(muted_role)
 
+        dm_message = discord.Embed(
+            title="Unmuted.",
+            description="You are now allowed to send messages in the server.",
+            color=colors["light_blue"],
+        )
+
+        await user.dm_channel.send(embed=dm_message)
+
         channel = self.bot.get_channel(Channels.modlog)
         await channel.send(f"{ctx.author.mention} unmuted {user.mention}.")
         await ctx.send(f"Successfully unmuted {user.mention}.")

--- a/bot/exts/moderation/moderation.py
+++ b/bot/exts/moderation/moderation.py
@@ -45,6 +45,22 @@ class Moderation(commands.Cog):
             await ctx.send("You can't ban yourself!")
             return
 
+        #gets current date and time; converts it with colons and slashes between then to make sense
+        current_time = datetime.now()
+        current_time = current_time.strftime("%H:%M:%S")
+
+        current_date = datetime.date()
+        current_date = current_date.strftime("%d/%m/%y")
+
+        #dm embed made here
+        dm_message = discord.Embed(
+            title = "**Infraction**: Ban",
+            description = f"You just got banned from the `{ctx.guild}` server.\n`reason:` {reason}\n`date and time:` {current_time} {current_date}",
+            color = colors["light_blue"]
+        )
+
+        await user.dm_channel.send(embed=dm_message)
+
         await ctx.guild.ban(user)
         await ctx.send(f"Successfully banned {user.name}")
 
@@ -105,6 +121,22 @@ class Moderation(commands.Cog):
         )
 
         await user.add_roles(muted_role)
+
+        #gets current date and time; converts it with colons and slashes between then to make sense
+        current_time = datetime.now()
+        current_time = current_time.strftime("%H:%M:%S")
+
+        current_date = datetime.date()
+        current_date = current_date.strftime("%d/%m/%y")
+
+        #dm embed made here
+        dm_message = discord.Embed(
+            title = "**Infraction**: Mute",
+            description = f"You just got muted from the `{ctx.guild}` server.\n`duration:` until {unmute_time}\n`reason:` {reason}\n`date and time:` {current_time} {current_date}",
+            color = colors["light_blue"]
+        )
+
+        await user.dm_channel.send(embed=dm_message)
 
         json_input = {user.id: unmute_time.timestamp()}
         try:

--- a/bot/exts/moderation/moderation.py
+++ b/bot/exts/moderation/moderation.py
@@ -21,6 +21,7 @@ UNMUTE_FILE = os.path.join(
 
 colors = get_yaml_val("config.yml", "colors")["colors"]
 
+
 class Moderation(commands.Cog):
     """Cog for moderation commands."""
 

--- a/bot/exts/moderation/moderation.py
+++ b/bot/exts/moderation/moderation.py
@@ -19,6 +19,7 @@ UNMUTE_FILE = os.path.join(
     "unmute_times.txt",
 )
 
+colors = get_yaml_val("config.yml", "colors")["colors"]
 
 class Moderation(commands.Cog):
     """Cog for moderation commands."""


### PR DESCRIPTION
Closes #66 
This PR makes the bot send a dm embed to the person getting infracted. I've only added this functionality to the Mute and Ban commands (should this be inculcated to the unmute command too? something like a "you have now been unmuted" ?) 

After looking at the code, you might be wondering as to why I made changes to the end of the mute function and similarly to the beginning of the ban function. This is because, the bot and the user has to be in a common server for dms to work. If I try to make the bot send a dm AFTER the person gets banned, I'm assuming that there will be an error since the person isn't in the server anymore.
```
Ankith
```